### PR TITLE
Created Scripts to Manage Development v.s Test Database

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,16 @@
 # Overview
 Backend folder for our data analytics website
 
+# Quickstart
+Create the development database and populate it with a couple values:
+
+``npm run init-dev``
+If you get an error after running the previous command, then you likely already have database at database/data.db.
+
+Start the server:
+
+``npm run start``
+
 # How To
 
 ## Running Python Microservices

--- a/backend/database/db-lib.js
+++ b/backend/database/db-lib.js
@@ -1,0 +1,27 @@
+const db = require("./db")
+function fillDevelopmentDatabase() {
+	const now = new Date().toISOString().slice(0, 19).replace('T', ' ');
+	const date = "2025-10-26 13:19:50"	
+	const vehicles_stmt = db.prepare(`
+		INSERT INTO Vehicle (id, title, description, uploaded_at, updated_at) VALUES 
+		('1', 'OR-9', 'A beautiful vintage Off-Road vehicle, perfect for the clay at Iron Mountain','${now}','${now}'),
+		('2', 'OR-X', 'Our newest Off-Road vehicle','${now}','${now}')
+		`);
+	const location_stmt = db.prepare(`
+		INSERT INTO Location (id, title, description, competition, latitude, longitude, created_at, updated_at,  parent_id)
+		VALUES
+		('1', 'Iron Mountain', 'Iron Moutain testing track, located near Dahlonega', 0, 34.5473261,-84.1448203,'${now}','${now}', NULL)
+		`);
+	const dataset_stmt = db.prepare(`
+		INSERT INTO Dataset (id, title, description, date, uploaded_at, updated_at, location_id, vehicle_id, competition)
+		VALUES
+		('1', '2025-10-26 13_19_50 (First Run)', 'RPM 4 (engine RPM) is useless. Rear RPM is very noisy. Rear brake pressure values seem plausible, front brake pressure useless.',
+		'${date}','${now}','${now}','1', '1', 0)
+		`);
+
+	vehicles_stmt.run()
+	location_stmt.run()
+	dataset_stmt.run()
+}
+
+module.exports = {fillDevelopmentDatabase};

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,8 +4,9 @@
   "description": "Backend service for the DAQAnalytics website",
   "main": "index.js",
   "scripts": {
-    "start": "node --env-file=.prod.env index.js",
-    "test": "python database/manage.py refresh database/migrations/ database/test.db && cross-env DATABASE_PATH=database/test.db jest --verbose --coverage"
+    "start": "bash scripts/start.sh",
+    "init-dev": "bash scripts/init-dev.sh",
+    "test": "bash scripts/test.sh"
   },
   "author": "Georgia Tech Offroad Data Analytics Subteam",
   "license": "MIT",

--- a/backend/scripts/init-dev.js
+++ b/backend/scripts/init-dev.js
@@ -1,0 +1,3 @@
+const dbLib = require("../database/db-lib")
+
+dbLib.fillDevelopmentDatabase()

--- a/backend/scripts/init-dev.sh
+++ b/backend/scripts/init-dev.sh
@@ -1,0 +1,5 @@
+python database/manage.py migrate database/migrations/ database/data.db &&
+cross-env \
+DATABASE_PATH=database/data.db \
+node scripts/init-dev.js \
+echo "Populated development database!"

--- a/backend/scripts/start.sh
+++ b/backend/scripts/start.sh
@@ -1,0 +1,3 @@
+cross-env \
+DATABASE_PATH=database/data.db \
+node index.js

--- a/backend/scripts/test.sh
+++ b/backend/scripts/test.sh
@@ -1,0 +1,4 @@
+python database/manage.py refresh database/migrations/ database/test.db && 
+cross-env \
+DATABASE_PATH=database/test.db \
+jest --verbose --coverage


### PR DESCRIPTION
Scripts that manage development database are complete. Running ``npm run dev-init`` will create the devleopment database at data.db with all the migrations in database/migrations/. Additionally, this command will populate this database with values from
data/db-lib.js:fillDevelopmentDatabase(). Scripts have been moved into a seperate folder for organization.